### PR TITLE
bumping transformers down to 0.2

### DIFF
--- a/pipes-vector.cabal
+++ b/pipes-vector.cabal
@@ -14,7 +14,7 @@ cabal-version:       >=1.10
 library
   exposed-modules:     Pipes.Vector
   build-depends:       base >=3.0 && <5,
-                       transformers >= 0.3 && < 1.0,
+                       transformers >= 0.2 && < 1.0,
                        primitive >=0.4 && <1.0,
                        pipes >=4.0 && <5.0,
                        vector >=0.9 && <1.0


### PR DESCRIPTION
pipes is running off of transformers >= 0.2, and hence fails on pipes-ecosystem
