### PR TITLE
Generalize the type using the monad-primitive package

### DIFF
--- a/pipes-vector.cabal
+++ b/pipes-vector.cabal
@@ -17,5 +17,7 @@ library
                        transformers >= 0.2 && < 1.0,
                        primitive >=0.4 && <1.0,
                        pipes >=4.0 && <5.0,
-                       vector >=0.9 && <1.0
+                       vector >=0.9 && <1.0,
+                       monad-primitive >= 0.1 && < 1.0
   default-language:    Haskell2010
+  extensions:          TypeFamilies


### PR DESCRIPTION
Generalize the type using the monad-primitive package 
(I use pipes-vector in the Cloud Haskell Process Monad, also in the pipes-safe SafeT monad)

Add fromProducer convenience function
