### PR TITLE
Remove monad-primitive dependency

### DIFF
--- a/pipes-vector.cabal
+++ b/pipes-vector.cabal
@@ -18,8 +18,7 @@ library
                        transformers >= 0.2 && < 1.0,
                        primitive >=0.6 && <0.7,
                        pipes >=4.0 && <5.0,
-                       vector >=0.9 && <1.0,
-                       monad-primitive >= 0.1 && < 0.2
+                       vector >=0.9 && <1.0
   default-language:    Haskell2010
   other-extensions:    RankNTypes, FlexibleContexts, GeneralizedNewtypeDeriving, TypeFamilies
 

--- a/src/Pipes/Vector.hs
+++ b/src/Pipes/Vector.hs
@@ -22,7 +22,6 @@ import Control.Applicative
 import Control.Monad
 import Control.Monad.Trans.State.Strict as S
 import Control.Monad.Primitive
-import qualified Control.Monad.Primitive.Class as MP
 import Pipes
 import Pipes.Internal (unsafeHoist)
 import Pipes.Lift
@@ -47,15 +46,6 @@ instance PrimMonad m => PrimMonad (ToVector v e m) where
 instance PrimMonad m => PrimMonad (Proxy a' a b' b m) where
     type PrimState (Proxy a' a b' b m) = PrimState m
     primitive = lift .  primitive
-
--- monad-primitive instances (TODO: remove these)
-instance MP.MonadPrim m => MP.MonadPrim (Proxy a' a b' b m) where
-    type BasePrimMonad (Proxy a' a b' b m) = MP.BasePrimMonad m
-    liftPrim = lift . MP.liftPrim
-
-instance MP.MonadPrim m => MP.MonadPrim (ToVector v e m) where
-    type BasePrimMonad (ToVector v e m) = MP.BasePrimMonad m
-    liftPrim = TV . MP.liftPrim
 
 maxChunkSize :: Int
 maxChunkSize = 8*1024*1024


### PR DESCRIPTION
Since you've already got a *todo* comment in here to do this, I figured maybe this change would be welcome? :smiley: 

I'm hoping to get `pipes-vector` into Stackage, and removing the `monad-primitive` dependency should help.